### PR TITLE
Update bottle version to fix getargspec error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ charset-normalizer==2.0.7
 idna==3.3
 requests==2.26.0
 urllib3==1.26.7
-bottle==0.12.20
+bottle==0.13.1
 certifi==2021.10.8
 charset-normalizer==2.0.7
 idna==3.3


### PR DESCRIPTION
On the latest Python version, even with a clean installation, running the script may throw an error because of the outdated bottle package version. Python has depreciated the 'getargspec' and now uses 'getfullargspec' instead. This is fixed in the latter versions of bottle, and updating the bottle version seems to fix the issue without causing any backward compatibility issues with the server scripts.

Similar issue on [Ethereum Web3](https://github.com/ethereum/web3.py/issues/2704).